### PR TITLE
Allow Ruby up to 3.0.x

### DIFF
--- a/paperclip-deflater.gemspec
+++ b/paperclip-deflater.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = [">= 2.1", "< 3.0"]
+  gem.required_ruby_version = [">= 2.1", "< 3.1"]
 
   gem.add_runtime_dependency "kt-paperclip", ">= 6.3"
 


### PR DESCRIPTION
Not to be merged before Chargify update to 3.0 concludes.

Ref link: https://maxioevolution.atlassian.net/browse/PLAT-446