### PR TITLE
Remove coverage measurement; Allow Ruby up to 3.1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,8 @@ source 'https://rubygems.org'
 gem "gem-release"
 gem "pry"
 
-ruby_version = RUBY_VERSION
 paperclip_version = ENV['PAPERCLIP_VERSION']
 
 gem "paperclip", "~> #{paperclip_version}" if paperclip_version
-
-gem "activesupport", "< 5.0.0" if ruby_version =~ /^2\.1\./
 
 gemspec

--- a/paperclip-deflater.gemspec
+++ b/paperclip-deflater.gemspec
@@ -16,12 +16,10 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = [">= 2.1", "< 3.1"]
+  gem.required_ruby_version = [">= 2.1", "< 3.2"]
 
   gem.add_runtime_dependency "kt-paperclip", ">= 6.3"
 
   gem.add_development_dependency "rake", ">= 10.0", "< 13"
   gem.add_development_dependency "rspec", ">= 3.0", "< 4"
-  gem.add_development_dependency "simplecov", "~> 0.12"
-  gem.add_development_dependency "coveralls", "~> 0.8"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,4 @@
 require 'rubygems'
-require 'simplecov'
-require 'coveralls'
-Coveralls.wear!
-
-SimpleCov.start do
-  add_filter 'spec/'
-end
 
 require 'paperclip-deflater'
 


### PR DESCRIPTION
What: Remove coverage measurement
Why: It conflicts with Ruby 3.1 but we don't need it because we're not actively developing the gem.
